### PR TITLE
Refactor away the `create` function

### DIFF
--- a/kubespawner/proxy.py
+++ b/kubespawner/proxy.py
@@ -142,20 +142,19 @@ class KubeIngressProxy(Proxy):
             'component': self.component_label,
             'hub.jupyter.org/proxy-route': 'true',
         }
-        (
-            self.ingress_reflector,
-            self.service_reflector,
-            self.endpoint_reflector,
-        ) = asyncio.gather(
-            IngressReflector.create(
-                parent=self, namespace=self.namespace, labels=labels
-            ),
-            ServiceReflector.create(
-                parent=self, namespace=self.namespace, labels=labels
-            ),
-            EndpointsReflector.create(
-                parent=self, namespace=self.namespace, labels=labels
-            ),
+        self.ingress_reflector = IngressReflector(
+            parent=self, namespace=self.namespace, labels=labels
+        )
+        self.service_reflector = ServiceReflector(
+            parent=self, namespace=self.namespace, labels=labels
+        )
+        self.endpoint_reflector = EndpointsReflector(
+            self, namespace=self.namespace, labels=labels
+        )
+        await asyncio.gather(
+            self.ingress_reflector.start(),
+            self.service_reflector.start(),
+            self.endpoint_reflector.start(),
         )
 
     def _await_async_init(method):

--- a/kubespawner/reflector.py
+++ b/kubespawner/reflector.py
@@ -218,21 +218,6 @@ class ResourceReflector(LoggingConfigurable):
 
         self.watch_task = None
 
-    @classmethod
-    async def create(cls, *args, **kwargs):
-        """
-        This is a workaround: `__init__` cannot be async, but we want
-        to call async methods to instantiate a reflector in a usable state.
-
-        This method creates the reflector, and then loads Kubernetes config,
-        acquires an API client, and starts the watch task.
-
-        Use it to create a new Reflector object.
-        """
-        inst = cls(*args, **kwargs)
-        await inst.start()
-        return inst
-
     async def _list_and_update(self):
         """
         Update current list of resources by doing a full fetch.

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2317,7 +2317,6 @@ class KubeSpawner(Spawner):
             self.log.info(
                 f"Attempting to create pod {pod.metadata.name}, with timeout {request_timeout}"
             )
-            # Use asyncio.wait_for, _request_timeout seems unreliable?
             await asyncio.wait_for(
                 self.api.create_namespaced_pod(
                     self.namespace,

--- a/kubespawner/spawner.py
+++ b/kubespawner/spawner.py
@@ -2244,12 +2244,13 @@ class KubeSpawner(Spawner):
         previous_reflector = self.__class__.reflectors.get(key)
 
         if replace or not previous_reflector:
-            self.__class__.reflectors[key] = await ReflectorClass.create(
+            self.__class__.reflectors[key] = ReflectorClass(
                 parent=self,
                 namespace=self.namespace,
                 on_failure=on_reflector_failure,
                 **kwargs,
             )
+            await self.__class__.reflectors[key].start()
 
         if replace and previous_reflector:
             # we replaced the reflector, stop the old one


### PR DESCRIPTION
This is another PR to the PR https://github.com/jupyterhub/kubespawner/pull/563. I think with this, I'm happy about merging https://github.com/jupyterhub/kubespawner/pull/563 and requesting a final review from another KubeSpawner maintainer.

---

I was about to update the docstring of `create` that incorrectly still described it loaded kube config etc. I also planned to rename it to `create_and_start` which I felt was a relevant aspect of what the function did.

But, thinking about it, I figured we could just as well just remove the `create` function entirely. It was used four times in our code base. So instead of using that function, this PR now makes our code instantiate the Reflector objects first, and then await their start functions.

It also removed an seemingly, at least as part of this pr, outdated comment.